### PR TITLE
Fixes path to plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ enabled, and have five editable layers set up:
 The default firmware is kept as close to the original as possible, and only
 those plugins are enabled in addition that are required for Chrysalis.
 
- [plugin:EEPROM-Keymap]: https://github.com/keyboardio/Kaleidoscope/blob/master/doc/plugin/EEPROM-Keymap.md#readme
- [plugin:EEPROM-Settings]: https://github.com/keyboardio/Kaleidoscope/blob/master/doc/plugin/EEPROM-Settings.md#readme
- [plugin:FocusSerial]: https://github.com/keyboardio/Kaleidoscope/blob/master/doc/plugin/FocusSerial.md#readme
- [plugin:MouseKeys]: https://github.com/keyboardio/Kaleidoscope/blob/master/doc/plugin/MouseKeys.md#readme
- [plugin:OneShot]: https://github.com/keyboardio/Kaleidoscope/blob/master/doc/plugin/OneShot.md#readme
- [plugin:Qukeys]: https://github.com/keyboardio/Kaleidoscope/blob/master/doc/plugin/Qukeys.md#readme
- [plugin:SpaceCadet]: https://github.com/keyboardio/Kaleidoscope/blob/master/doc/plugin/SpaceCadet.md#readme
+ [plugin:EEPROM-Keymap]: https://github.com/keyboardio/Kaleidoscope/blob/master/docs/plugins/EEPROM-Keymap.md#readme
+ [plugin:EEPROM-Settings]: https://github.com/keyboardio/Kaleidoscope/blob/master/docs/plugins/EEPROM-Settings.md#readme
+ [plugin:FocusSerial]: https://github.com/keyboardio/Kaleidoscope/blob/master/docs/plugins/FocusSerial.md#readme
+ [plugin:MouseKeys]: https://github.com/keyboardio/Kaleidoscope/blob/master/docs/plugins/MouseKeys.md#readme
+ [plugin:OneShot]: https://github.com/keyboardio/Kaleidoscope/blob/master/docs/plugins/OneShot.md#readme
+ [plugin:Qukeys]: https://github.com/keyboardio/Kaleidoscope/blob/master/docs/plugins/Qukeys.md#readme
+ [plugin:SpaceCadet]: https://github.com/keyboardio/Kaleidoscope/blob/master/docs/plugins/SpaceCadet.md#readme
 
 Depending on the device, there may be other plugins enabled, please consult the
 sources for now.


### PR DESCRIPTION
The plugin documentation folder in the Kaleidoscope repo was moved as a result of commit keyboardio/Kaleidoscope@a60651054a5a2fb28b3aac517e67cbe4373b87ba. This updates the links to correctly point to the new location.