### PR TITLE
Correct plugin order

### DIFF
--- a/EZ/ErgoDox/experimental/ErgoDox.ino
+++ b/EZ/ErgoDox/experimental/ErgoDox.ino
@@ -115,10 +115,10 @@ KALEIDOSCOPE_INIT_PLUGINS(
   Focus,
   FocusEEPROMCommand,
   FocusSettingsCommand,
-  OneShot,
+  Qukeys,
   SpaceCadet,
+  OneShot,
   MouseKeys,
-  Qukeys
 );
 
 void blinkAllStatusLEDs() {

--- a/Keyboardio/Atreus/default/Atreus.ino
+++ b/Keyboardio/Atreus/default/Atreus.ino
@@ -106,11 +106,11 @@ KALEIDOSCOPE_INIT_PLUGINS(
   Focus,
   FocusEEPROMCommand,
   FocusSettingsCommand,
-  OneShot,
+  Qukeys,
   SpaceCadet,
-  MouseKeys,
+  OneShot,
   Macros,
-  Qukeys
+  MouseKeys,
 );
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {

--- a/Keyboardio/Model01/experimental/Model01.ino
+++ b/Keyboardio/Model01/experimental/Model01.ino
@@ -433,11 +433,11 @@ KALEIDOSCOPE_INIT_PLUGINS(
   // LEDControl provides support for other LED modes
   LEDControl,
 
-  ActiveModColorEffect,
-
-  OneShot,
   Qukeys,
   SpaceCadet,
+  OneShot,
+
+  ActiveModColorEffect,
 
   // We start with the LED effect that turns off all the LEDs.
   LEDOff,

--- a/SOFTHRUF/Splitography/experimental/Splitography.ino
+++ b/SOFTHRUF/Splitography/experimental/Splitography.ino
@@ -250,10 +250,10 @@ KALEIDOSCOPE_INIT_PLUGINS(
     EEPROMKeymap,
     FocusEEPROMCommand,
     FocusSettingsCommand,
-    OneShot,
+    Qukeys,
     SpaceCadet,
+    OneShot,
     MouseKeys,
-    Qukeys
 );
 
 void setup() {

--- a/Technomancy/Atreus/experimental/Atreus.ino
+++ b/Technomancy/Atreus/experimental/Atreus.ino
@@ -98,11 +98,11 @@ KALEIDOSCOPE_INIT_PLUGINS(
   Focus,
   FocusEEPROMCommand,
   FocusSettingsCommand,
-  OneShot,
+  Qukeys,
   SpaceCadet,
-  MouseKeys,
+  OneShot,
   Macros,
-  Qukeys
+  MouseKeys,
 );
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {


### PR DESCRIPTION
The order in which key events are processed by plugins is very important. In particular, there are several plugins that change the value of a key, or delay or abort key events entirely, and these plugins really need to come before the plugins that act on those key values. Specifically, Qukeys really needs to come before most other plugins that have `onKeyswitchEvent()` handlers.
