### PR TITLE
Keyboardio/Atreus: Remove trailing comma

### DIFF
--- a/Keyboardio/Atreus/default/Atreus.ino
+++ b/Keyboardio/Atreus/default/Atreus.ino
@@ -110,7 +110,7 @@ KALEIDOSCOPE_INIT_PLUGINS(
   SpaceCadet,
   OneShot,
   Macros,
-  MouseKeys,
+  MouseKeys
 );
 
 const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {


### PR DESCRIPTION
I ended up at this repo instead of at https://github.com/keyboardio/Kaleidoscope/tree/master/examples/Devices/Keyboardio/Atreus when trying to create my own firmware for my new Atreus. I came here via https://community.keyboard.io/t/make-flash-for-atreus/4175/6.

`make flash` wouldn't work for me without this change.