### PR TITLE
Update sketches for `KeyEvent` changes

### DIFF
--- a/Keyboardio/Atreus/default/Atreus/Atreus.ino
+++ b/Keyboardio/Atreus/default/Atreus/Atreus.ino
@@ -113,8 +113,8 @@ KALEIDOSCOPE_INIT_PLUGINS(
   MouseKeys
 );
 
-const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
-  switch (macroIndex) {
+const macro_t *macroAction(uint8_t macro_id, KeyEvent &event) {
+  switch (macro_id) {
   case MACRO_QWERTY:
     // This macro is currently unused, but is kept around for compatibility
     // reasons. We used to use it in place of `MoveToLayer(QWERTY)`, but no
@@ -123,7 +123,7 @@ const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
     Layer.move(QWERTY);
     break;
   case MACRO_VERSION_INFO:
-    if (keyToggledOn(keyState)) {
+    if (keyToggledOn(event.state)) {
       Macros.type(PSTR("Keyboardio Atreus - Kaleidoscope "));
       Macros.type(PSTR(BUILD_INFORMATION));
     }

--- a/Keyboardio/Model01/experimental/Model01/Makefile
+++ b/Keyboardio/Model01/experimental/Model01/Makefile
@@ -1,6 +1,8 @@
 # This makefile for a Kaleidoscope sketch pulls in all the targets
 # required to build the example
 
+# Compile without deprecated code to save space
+LOCAL_CFLAGS ?= -DNDEPRECATED
 
 
 

--- a/Keyboardio/Model01/experimental/Model01/Makefile
+++ b/Keyboardio/Model01/experimental/Model01/Makefile
@@ -2,7 +2,7 @@
 # required to build the example
 
 # Compile without deprecated code to save space
-LOCAL_CFLAGS ?= -DNDEPRECATED
+LOCAL_CFLAGS ?= -DNDEPRECATED -DONESHOT_WITHOUT_METASTICKY
 
 
 

--- a/Keyboardio/Model01/experimental/Model01/Model01.ino
+++ b/Keyboardio/Model01/experimental/Model01/Model01.ino
@@ -305,16 +305,11 @@ static void versionInfoMacro(uint8_t keyState) {
  *
  */
 
-static void anyKeyMacro(uint8_t keyState) {
-  static Key lastKey;
-  bool toggledOn = false;
-  if (keyToggledOn(keyState)) {
-    lastKey.setKeyCode(Key_A.getKeyCode() + (uint8_t)(millis() % 36));
-    toggledOn = true;
+static void anyKeyMacro(KeyEvent &event) {
+  if (keyToggledOn(event.state)) {
+    event.key.setKeyCode(Key_A.getKeyCode() + (uint8_t)(millis() % 36));
+    event.key.setFlags(0);
   }
-
-  if (keyIsPressed(keyState))
-    Kaleidoscope.hid().keyboard().pressKey(lastKey, toggledOn);
 }
 
 
@@ -330,15 +325,15 @@ static void anyKeyMacro(uint8_t keyState) {
 
  */
 
-const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
-  switch (macroIndex) {
+const macro_t *macroAction(uint8_t macro_id, KeyEvent &event) {
+  switch (macro_id) {
 
   case MACRO_VERSION_INFO:
-    versionInfoMacro(keyState);
+    versionInfoMacro(event.state);
     break;
 
   case MACRO_ANY:
-    anyKeyMacro(keyState);
+    anyKeyMacro(event);
     break;
   }
   return MACRO_NONE;

--- a/Keyboardio/Model01/experimental/Model01/Model01.ino
+++ b/Keyboardio/Model01/experimental/Model01/Model01.ino
@@ -447,13 +447,16 @@ KALEIDOSCOPE_INIT_PLUGINS(
 
   // The chase effect follows the adventure of a blue pixel which chases a red pixel across
   // your keyboard. Spoiler: the blue pixel never catches the red pixel
-  LEDChaseEffect,
+  // TODO(anyone): Currently disabled to save space
+  // LEDChaseEffect,
 
   // These static effects turn your keyboard's LEDs a variety of colors
-  //solidRed, solidOrange, solidYellow, solidGreen, solidBlue, solidIndigo, solidViolet,
+  // TODO(anyone): Currently disabled to save space
+  // solidRed, solidOrange, solidYellow, solidGreen, solidBlue, solidIndigo, solidViolet,
 
   // The breathe effect slowly pulses all of the LEDs on your keyboard
-  LEDBreatheEffect,
+  // TODO(anyone): Currently disabled to save space
+  // LEDBreatheEffect,
 
   // The AlphaSquare effect prints each character you type, using your
   // keyboard's LEDs as a display
@@ -461,7 +464,8 @@ KALEIDOSCOPE_INIT_PLUGINS(
   // AlphaSquareEffect,
 
   // The stalker effect lights up the keys you've pressed recently
-  StalkerEffect,
+  // TODO(anyone): Currently disabled to save space
+  // StalkerEffect,
 
   // The Colormap effect makes it possible to set up per-layer colormaps
   ColormapEffect,
@@ -507,7 +511,7 @@ void setup() {
   NumPad.numPadLayer = NUMPAD;
 
   // We configure the AlphaSquare effect to use RED letters
-  AlphaSquare.color = CRGB(255, 0, 0);
+  //AlphaSquare.color = CRGB(255, 0, 0);
 
   // We set the brightness of the rainbow effects to 150 (on a scale of 0-255)
   // This draws more than 500mA, but looks much nicer than a dimmer effect
@@ -517,7 +521,7 @@ void setup() {
   // The LED Stalker mode has a few effects. The one we like is called
   // 'BlazingTrail'. For details on other options, see
   // https://github.com/keyboardio/Kaleidoscope/blob/master/doc/plugin/LED-Stalker.md
-  StalkerEffect.variant = STALKER(BlazingTrail);
+  //StalkerEffect.variant = STALKER(BlazingTrail);
 
   // We want to make sure that the firmware starts with LED effects off
   // This avoids over-taxing devices that don't have a lot of power to share

--- a/SOFTHRUF/Splitography/default/Splitography/Splitography.ino
+++ b/SOFTHRUF/Splitography/default/Splitography/Splitography.ino
@@ -211,19 +211,19 @@ class MultiSwitcher : public kaleidoscope::Plugin {
  public:
   MultiSwitcher() {}
 
-  EventHandlerResult onKeyswitchEvent(Key &key, KeyAddr key_addr, uint8_t key_state) {
-    if (key < QWERTY_1 || key > QWERTY_2)
+  EventHandlerResult onKeyEvent(KeyEvent &event) {
+    if (event.key < QWERTY_1 || event.key > QWERTY_2)
       return EventHandlerResult::OK;
 
-    uint8_t bit = key.getRaw() - QWERTY_1;
+    uint8_t bit = event.key.getRaw() - QWERTY_1;
 
-    if (keyIsPressed(key_state)) {
+    if (keyToggledOn(event.state)) {
       switch_state_ |= (1 << bit);
 
       if (switch_state_ == (1 << 0 | 1 << 1)) {
         Layer.move(_QWERTY);
       }
-    } else if (keyToggledOff(key_state)) {
+    } else {
       switch_state_ &= ~(1 << bit);
     }
 

--- a/SOFTHRUF/Splitography/experimental/Splitography/Splitography.ino
+++ b/SOFTHRUF/Splitography/experimental/Splitography/Splitography.ino
@@ -214,19 +214,19 @@ class MultiSwitcher : public kaleidoscope::Plugin {
  public:
   MultiSwitcher() {}
 
-  EventHandlerResult onKeyswitchEvent(Key &key, KeyAddr key_addr, uint8_t key_state) {
-    if (key < QWERTY_1 || key > QWERTY_2)
+  EventHandlerResult onKeyEvent(KeyEvent &event) {
+    if (event.key < QWERTY_1 || event.key > QWERTY_2)
       return EventHandlerResult::OK;
 
-    uint8_t bit = key.getRaw() - QWERTY_1;
+    uint8_t bit = event.key.getRaw() - QWERTY_1;
 
-    if (keyIsPressed(key_state)) {
+    if (keyToggledOn(event.state)) {
       switch_state_ |= (1 << bit);
 
       if (switch_state_ == (1 << 0 | 1 << 1)) {
         Layer.move(_QWERTY);
       }
-    } else if (keyToggledOff(key_state)) {
+    } else {
       switch_state_ &= ~(1 << bit);
     }
 

--- a/Technomancy/Atreus/default/Atreus/Atreus.ino
+++ b/Technomancy/Atreus/default/Atreus/Atreus.ino
@@ -97,8 +97,8 @@ KALEIDOSCOPE_INIT_PLUGINS(
   Macros
 );
 
-const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
-  switch (macroIndex) {
+const macro_t *macroAction(uint8_t macro_id, KeyEvent &event) {
+  switch (macro_id) {
   case RESET:
     Kaleidoscope.rebootBootloader();
     break;

--- a/Technomancy/Atreus/experimental/Atreus/Atreus.ino
+++ b/Technomancy/Atreus/experimental/Atreus/Atreus.ino
@@ -105,8 +105,8 @@ KALEIDOSCOPE_INIT_PLUGINS(
   MouseKeys
 );
 
-const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
-  switch (macroIndex) {
+const macro_t *macroAction(uint8_t macro_id, KeyEvent &event) {
+  switch (macro_id) {
   case RESET:
     Kaleidoscope.rebootBootloader();
     break;


### PR DESCRIPTION
This updates a bunch of firmware sketches to use the new `macroAction()` function.

In addition, the Model01 sketch was too big to fit in PROGMEM, so I removed some LED plugins, and changed the makefile so that it would be compiled with `NDEPRECATED` defined to save even more space.