### PR TITLE
Keyboardio/Model100 & Atreus: Enable the LayerNames plugin

### DIFF
--- a/Keyboardio/Atreus/Atreus.ino
+++ b/Keyboardio/Atreus/Atreus.ino
@@ -33,6 +33,7 @@
 #include "Kaleidoscope-Qukeys.h"
 #include "Kaleidoscope-SpaceCadet.h"
 #include "Kaleidoscope-DynamicMacros.h"
+#include "Kaleidoscope-LayerNames.h"
 
 #define MO(n) ShiftToLayer(n)
 #define TG(n) LockLayer(n)
@@ -115,7 +116,8 @@ KALEIDOSCOPE_INIT_PLUGINS(
   DynamicMacros,
   MouseKeys,
   EscapeOneShotConfig,
-  FirmwareVersion);
+  FirmwareVersion,
+  LayerNames);
 
 const macro_t *macroAction(uint8_t macro_id, KeyEvent &event) {
   if (keyToggledOn(event.state)) {
@@ -141,9 +143,11 @@ const macro_t *macroAction(uint8_t macro_id, KeyEvent &event) {
 void setup() {
   Kaleidoscope.setup();
   SpaceCadet.disable();
-  EEPROMKeymap.setup(10);
+  EEPROMKeymap.setup(9);
 
   DynamicMacros.reserve_storage(48);
+
+  LayerNames.reserve_storage(63);
 
   Layer.move(EEPROMSettings.default_layer());
 }

--- a/Keyboardio/Model100/Model100.ino
+++ b/Keyboardio/Model100/Model100.ino
@@ -94,6 +94,9 @@
 // Support for SpaceCadet keys
 #include "Kaleidoscope-SpaceCadet.h"
 
+// Support for editable layer names
+#include "Kaleidoscope-LayerNames.h"
+
 /** This 'enum' is a list of all the macros used by the Model 100's firmware
   * The names aren't particularly important. What is important is that each
   * is unique.
@@ -575,7 +578,11 @@ KALEIDOSCOPE_INIT_PLUGINS(
 
   // The FirmwareVersion plugin lets Chrysalis query the version of the firmware
   // programmatically.
-  FirmwareVersion);
+  FirmwareVersion,
+
+  // The LayerNames plugin allows Chrysalis to display - and edit - custom layer
+  // names, to be shown instead of the default indexes.
+  LayerNames);
 
 /** The 'setup' function is one of the two standard Arduino sketch functions.
  * It's called when your keyboard first powers up. This is where you set up
@@ -636,6 +643,11 @@ void setup() {
 
   // To avoid any surprises, SpaceCadet is turned off by default.
   SpaceCadet.disable();
+
+  // Editable layer names are stored in EEPROM too, and we reserve 16 bytes per
+  // layer for them. We need one extra byte per layer for bookkeeping, so we
+  // reserve 17 / layer in total.
+  LayerNames.reserve_storage(17 * 8);
 }
 
 /** loop is the second of the standard Arduino sketch functions.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,15 @@ Chrysalis-Firmware-Bundle 0.10.5-snapshot
 =========================================
 **UNRELEASED**
 
-The Keyboardio Model 100 firmware now ships with the `LayerNames` plugin
-enabled, allowing Chrysalis to set custom layer names.
+Keyboardio Model 100 & Atreus
+-----------------------------
+
+The Keyboardio Model 100 and Atreus firmwares now ships with the `LayerNames**
+plugin enabled, allowing Chrysalis to set custom layer names.
+
+**NOTE**: In case of the Keyboardio Atreus, this required us to reduce the
+number of layers in the default firmware from 10 to 9, to free up some EEPROM
+space. This is a breaking change.
 
 Chrysalis-Firmware-Bundle 0.10.4
 ================================

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@ Chrysalis-Firmware-Bundle 0.10.5-snapshot
 =========================================
 **UNRELEASED**
 
-No changes yet.
+The Keyboardio Model 100 firmware now ships with the `LayerNames` plugin
+enabled, allowing Chrysalis to set custom layer names.
 
 Chrysalis-Firmware-Bundle 0.10.4
 ================================


### PR DESCRIPTION
To allow Chrysalis to set and use custom layer names, enable the necessary plugin for the Model 100, and for the Atreus. For the Atreus, this is a breaking change, because one EEPROM layer had to be removed to free up storage (as discussed in #18).

We do not enable it for the other firmware, due to lack of storage space.