### PR TITLE
Model01 & Model100: Turn the LEDs off when going to sleep

### DIFF
--- a/Keyboardio/Model01/Model01.ino
+++ b/Keyboardio/Model01/Model01.ino
@@ -357,12 +357,11 @@ static kaleidoscope::plugin::LEDSolidColor solidViolet(130, 0, 120);
 void toggleLedsOnSuspendResume(kaleidoscope::plugin::HostPowerManagement::Event event) {
   switch (event) {
   case kaleidoscope::plugin::HostPowerManagement::Suspend:
+  case kaleidoscope::plugin::HostPowerManagement::Sleep:
     LEDControl.disable();
     break;
   case kaleidoscope::plugin::HostPowerManagement::Resume:
     LEDControl.enable();
-    break;
-  case kaleidoscope::plugin::HostPowerManagement::Sleep:
     break;
   }
 }

--- a/Keyboardio/Model100/Model100.ino
+++ b/Keyboardio/Model100/Model100.ino
@@ -380,12 +380,11 @@ static kaleidoscope::plugin::LEDSolidColor solidViolet(130, 0, 120);
 void toggleLedsOnSuspendResume(kaleidoscope::plugin::HostPowerManagement::Event event) {
   switch (event) {
   case kaleidoscope::plugin::HostPowerManagement::Suspend:
+  case kaleidoscope::plugin::HostPowerManagement::Sleep:
     LEDControl.disable();
     break;
   case kaleidoscope::plugin::HostPowerManagement::Resume:
     LEDControl.enable();
-    break;
-  case kaleidoscope::plugin::HostPowerManagement::Sleep:
     break;
   }
 }


### PR DESCRIPTION
We were turning the LEDs off when the host suspended, but not when it went to sleep. Thus, the LEDs remained on in that case unless the hosts' sleep procedure involved going into suspend first.

Lets turn the LEDs explicitly off on sleep.