### PR TITLE
Enable a few more plugins for the Keyboardio Atreus

### DIFF
--- a/Keyboardio/Atreus/Atreus.ino
+++ b/Keyboardio/Atreus/Atreus.ino
@@ -117,7 +117,10 @@ KALEIDOSCOPE_INIT_PLUGINS(
   MouseKeys,
   EscapeOneShotConfig,
   FirmwareVersion,
-  LayerNames);
+  LayerNames,
+  SpaceCadetConfig,
+  OneShotConfig,
+  MouseKeysConfig);
 
 const macro_t *macroAction(uint8_t macro_id, KeyEvent &event) {
   if (keyToggledOn(event.state)) {


### PR DESCRIPTION
Kaleidoscope recently added a few plugins that lets Chrysalis configure certain aspects of plugins used on the Atreus too, such as SpaceCadet, MouseKeys, and OneShot. Since we still have a little space left on the Atreus' EEPROM, lets enable the *Config plugins for these three.

I'm only adding it to the Atreus, because the Model01 firmware is too tight - it may have space in EEPROM, but the program size is dangerously close. I want to have a little wiggle room.

Among other things, this fixes keyboardio/Chrysalis#746.